### PR TITLE
✨ feat: Sparkline form graph per player in results table

### DIFF
--- a/frontend/features/geoguessr/README.md
+++ b/frontend/features/geoguessr/README.md
@@ -4,31 +4,24 @@ All GeoGuessr scoreboard logic, components, and hooks.
 
 ## Structure
 
-| Path                      | Contents                                                                |
-| ------------------------- | ----------------------------------------------------------------------- |
-| `constants.ts`            | `PLAYER_COLORS`, `getPlayerColor`, `getChartSeries`, `formatAxisNumber` |
-| `hooks/useResults.ts`     | Shared hook — year state + data fetching for Results and Stats pages    |
-| `hooks/useRoundDetail.ts` | Fetches a single round by ID, derives `RoundDetailData` and podium      |
-
-<<<<<<< feat/player-profile-page
-| `hooks/usePlayerProfile.ts` | Fetches all results and derives player stats, rank history, and streak for `/players/:name` |
-=======
-
-> > > > > > > main
-> > > > > > > | `components/dashboardSection.tsx` | Paper section wrapper used across dashboard |
-> > > > > > > | `components/podiumCard.tsx` | Gold/silver/bronze podium display (top 3 by wins) |
-> > > > > > > | `components/lastRoundCard.tsx` | Ranked last round results |
-> > > > > > > | `components/yearSelector.tsx` | Reusable year dropdown |
-> > > > > > > | `components/addScoreModal.tsx` | Modal for adding a new round score |
-> > > > > > > | `logic/podium.ts` | `getPodium()` — returns top 3 players by wins |
-> > > > > > > | `logic/lastRound.ts` | `getLastRound()` — returns latest round rankings |
-> > > > > > > | `logic/roundDetail.ts` | `getRoundDetail()` — sorted rankings with delta vs season average; `getRoundPodium()` — top-3 entries from a detail result |
-> > > > > > > <<<<<<< feat/player-profile-page
-
-# | `logic/playerProfile.ts` | `getPlayerStats()` — all-time stats per player; `getPlayerRankHistory()` — cumulative season rank per round date |
-
-> > > > > > > main
-> > > > > > > | `logic/` | Other pure data-transformation helpers (results, scores, players, etc.) |
+| Path                                   | Contents                                                                                                                              |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `constants.ts`                         | `PLAYER_COLORS`, `getPlayerColor`, `getChartSeries`, `formatAxisNumber`                                                               |
+| `hooks/useResults.ts`                  | Shared hook — year state + data fetching for Results and Stats pages                                                                  |
+| `hooks/useRoundDetail.ts`              | Fetches a single round by ID, derives `RoundDetailData` and podium                                                                    |
+| `hooks/usePlayerProfile.ts`            | Fetches all results and derives player stats, rank history, and streak for `/players/:name`                                           |
+| `components/dashboardSection.tsx`      | Paper section wrapper used across dashboard                                                                                           |
+| `components/podiumCard.tsx`            | Gold/silver/bronze podium display (top 3 by wins)                                                                                     |
+| `components/lastRoundCard.tsx`         | Ranked last round results                                                                                                             |
+| `components/yearSelector.tsx`          | Reusable year dropdown                                                                                                                |
+| `components/addScoreModal.tsx`         | Modal for adding a new round score                                                                                                    |
+| `components/playerSparklineHeader.tsx` | DataGrid column header: player name + inline `SparkLineChart` (last N scores); sparkline only rendered when player has 2+ data points |
+| `logic/podium.ts`                      | `getPodium()` — returns top 3 players by wins                                                                                         |
+| `logic/lastRound.ts`                   | `getLastRound()` — returns latest round rankings                                                                                      |
+| `logic/roundDetail.ts`                 | `getRoundDetail()` — sorted rankings with delta vs season average; `getRoundPodium()` — top-3 entries from a detail result            |
+| `logic/playerProfile.ts`               | `getPlayerStats()` — all-time stats per player; `getPlayerRankHistory()` — cumulative season rank per round date                      |
+| `logic/playerSparkline.ts`             | `getPlayerSparklineData(results, player, limit=5)` — last N scores for a player (played rounds only, sorted date ascending)           |
+| `logic/`                               | Other pure data-transformation helpers (results, scores, players, etc.)                                                               |
 
 ## Rules
 
@@ -36,6 +29,5 @@ All GeoGuessr scoreboard logic, components, and hooks.
 - **Must** add shared chart/colour helpers to `constants.ts` — not inline in components.
 - `useResults.ts` is the single source for year-state + fetch logic — reuse it, don't duplicate.
 - `useRoundDetail.ts` is the single source for per-round fetch + derivation logic — reuse it, don't duplicate.
-  <<<<<<< feat/player-profile-page
-- # `usePlayerProfile.ts` is the single source for per-player stats, rank history, and streak — reuse it, don't duplicate.
-  > > > > > > > main
+- `usePlayerProfile.ts` is the single source for per-player stats, rank history, and streak — reuse it, don't duplicate.
+- `getPlayerSparklineData` filters to played rounds only — never pass raw scores containing `null`/absent entries to a chart.

--- a/frontend/features/geoguessr/components/playerSparklineHeader.tsx
+++ b/frontend/features/geoguessr/components/playerSparklineHeader.tsx
@@ -1,0 +1,47 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { SparkLineChart } from '@mui/x-charts/SparkLineChart';
+
+interface PlayerSparklineHeaderProps {
+  name: string;
+  color: string;
+  data: number[];
+}
+
+export const PlayerSparklineHeader = ({
+  name,
+  color,
+  data,
+}: PlayerSparklineHeaderProps) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+        gap: 0.75,
+        width: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      {data.length >= 2 && (
+        <SparkLineChart
+          data={data}
+          width={52}
+          height={22}
+          plotType="line"
+          color={color}
+          disableAxisListener
+          sx={{ flexShrink: 0 }}
+        />
+      )}
+      <Typography
+        variant="inherit"
+        noWrap
+        sx={{ fontWeight: 500, lineHeight: 1.2 }}
+      >
+        {name}
+      </Typography>
+    </Box>
+  );
+};

--- a/frontend/features/geoguessr/logic/index.ts
+++ b/frontend/features/geoguessr/logic/index.ts
@@ -1,4 +1,5 @@
 export { getActivePlayers } from './players';
+export { getPlayerSparklineData } from './playerSparkline';
 export { getPlayerDetails } from './player-details';
 export { getPerPlayedRoundDetails } from './per-played-round-details';
 export { getPlayerData } from './player-series';

--- a/frontend/features/geoguessr/logic/playerSparkline.ts
+++ b/frontend/features/geoguessr/logic/playerSparkline.ts
@@ -1,0 +1,15 @@
+import { isPlayedScore } from './scores';
+
+import type { GameResult } from './types';
+
+export const getPlayerSparklineData = (
+  results: GameResult[],
+  player: string,
+  limit = 5,
+): number[] => {
+  return results
+    .filter((r) => isPlayedScore(r.scores[player]))
+    .toSorted((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    .slice(-limit)
+    .map((r) => r.scores[player] as number);
+};

--- a/frontend/pages/README.md
+++ b/frontend/pages/README.md
@@ -2,16 +2,16 @@
 
 One file per route. Pages are intentionally thin — they import and compose feature components, they do not own logic themselves.
 
-| File                    | Route               | Content                                                                                                                        |
-| ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `homePage.tsx`          | `/`                 | Season Podium (top 3 by wins) + Last Round card                                                                                |
-| `hallOfFamePage.tsx`    | `/hall-of-fame`     | Three all-time record cards: highest single-round score, longest win streak, best season total — public                        |
-| `resultsPage.tsx`       | `/results`          | Points DataGrid + Weekly LineChart + year selector, with dense phone-friendly table and chart handling                         |
-| `statsPage.tsx`         | `/stats`            | Won vs Played, Points Per Round, Accumulated Points charts + year selector, with small-screen chart polish                     |
-| `loginPage.tsx`         | `/login`            | Login form (direct URL access; TopNav uses `LoginModal` instead)                                                               |
-| `notFoundPage.tsx`      | `*`                 | 404 fallback (protected route)                                                                                                 |
-| `playerProfilePage.tsx` | `/players/:name`    | Name, avatar, all-time stats (rounds, wins, win rate, personal best), current win streak, cumulative season rank history chart |
-| `roundDetailPage.tsx`   | `/results/:roundId` | Podium + score breakdown table for a single round, with delta vs season average                                                |
+| File                    | Route               | Content                                                                                                                                                                                 |
+| ----------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `homePage.tsx`          | `/`                 | Season Podium (top 3 by wins) + Last Round card                                                                                                                                         |
+| `hallOfFamePage.tsx`    | `/hall-of-fame`     | Three all-time record cards: highest single-round score, longest win streak, best season total — public                                                                                 |
+| `resultsPage.tsx`       | `/results`          | Points DataGrid (player column headers show `PlayerSparklineHeader` with last-5 score sparkline) + Weekly LineChart + year selector, with dense phone-friendly table and chart handling |
+| `statsPage.tsx`         | `/stats`            | Won vs Played, Points Per Round, Accumulated Points charts + year selector, with small-screen chart polish                                                                              |
+| `loginPage.tsx`         | `/login`            | Login form (direct URL access; TopNav uses `LoginModal` instead)                                                                                                                        |
+| `notFoundPage.tsx`      | `*`                 | 404 fallback (protected route)                                                                                                                                                          |
+| `playerProfilePage.tsx` | `/players/:name`    | Name, avatar, all-time stats (rounds, wins, win rate, personal best), current win streak, cumulative season rank history chart                                                          |
+| `roundDetailPage.tsx`   | `/results/:roundId` | Podium + score breakdown table for a single round, with delta vs season average                                                                                                         |
 
 ## Rules
 

--- a/frontend/pages/resultsPage.tsx
+++ b/frontend/pages/resultsPage.tsx
@@ -16,15 +16,18 @@ import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 import { DashboardSection } from '@frontend/features/geoguessr/components/dashboardSection';
+import { PlayerSparklineHeader } from '@frontend/features/geoguessr/components/playerSparklineHeader';
 import { YearSelector } from '@frontend/features/geoguessr/components/yearSelector';
 import {
   getChartSeries,
   formatAxisNumber,
+  getPlayerColor,
 } from '@frontend/features/geoguessr/constants';
 import { useResults } from '@frontend/features/geoguessr/hooks/useResults';
 import {
   getActivePlayers,
   getPlayerData,
+  getPlayerSparklineData,
 } from '@frontend/features/geoguessr/logic';
 import { TableSkeleton } from '@frontend/shared/components/skeleton';
 
@@ -80,6 +83,19 @@ export const ResultsPage = () => {
       }),
     [playerData, players, results],
   );
+  const playerSparklineData = useMemo(
+    () =>
+      Object.fromEntries(
+        players.map((p, i) => [
+          p,
+          {
+            data: getPlayerSparklineData(results, p),
+            color: getPlayerColor(p, i),
+          },
+        ]),
+      ),
+    [players, results],
+  );
   const gridColumns = useMemo<GridColDef<PointsGridRow>[]>(
     () => [
       { field: 'date', headerName: 'Date', minWidth: 140, flex: 1 },
@@ -87,14 +103,21 @@ export const ResultsPage = () => {
         field: p,
         headerName: p,
         type: 'number' as const,
-        minWidth: 120,
+        minWidth: 140,
         flex: 1,
         align: 'right' as const,
         headerAlign: 'right' as const,
         valueFormatter: (value: number) => formatAxisNumber(value),
+        renderHeader: () => (
+          <PlayerSparklineHeader
+            name={p}
+            color={playerSparklineData[p]?.color ?? '#666666'}
+            data={playerSparklineData[p]?.data ?? []}
+          />
+        ),
       })),
     ],
-    [players],
+    [players, playerSparklineData],
   );
 
   const noResults = !isLoading && !error && playerData.length === 0;


### PR DESCRIPTION
Fixes #330

## Summary

Adds a tiny inline sparkline to each player column header in the Results table, showing their score trend over their last 5 participated rounds.

## Changes

- **`logic/playerSparkline.ts`** — `getPlayerSparklineData(results, player, limit=5)` filters to rounds where the player actually played (score > 0), sorts by date, returns last N scores
- **`components/playerSparklineHeader.tsx`** — renders player name + `SparkLineChart` inline; sparkline hidden if < 2 data points
- **`pages/resultsPage.tsx`** — player columns use `renderHeader` with colour-matched sparklines; `minWidth` bumped to 140
- READMEs updated

## Acceptance criteria

- ✅ Sparkline shown when player has 2+ rounds
- ✅ No sparkline shown with < 2 rounds
- ✅ Sparkline reflects up/down trend visually
- ✅ Uses up to last 5 participated rounds
- ✅ No axis labels or tooltips
- ✅ Does not block table layout