### PR TITLE
✨ feat: add frontend startup logs for analytics and OTel

### DIFF
--- a/frontend/features/analytics/analyticsProvider.tsx
+++ b/frontend/features/analytics/analyticsProvider.tsx
@@ -8,6 +8,12 @@ const { clientId, apiUrl, sessionReplay } = config.openpanel;
 
 export const isEnabled = Boolean(clientId);
 
+if (isEnabled) {
+  console.log('📊 Analytics enabled (OpenPanel)');
+} else {
+  console.log('📊 Analytics disabled');
+}
+
 export const op = isEnabled
   ? new OpenPanel({
       clientId: clientId!,

--- a/frontend/telemetry/telemetry.ts
+++ b/frontend/telemetry/telemetry.ts
@@ -46,6 +46,7 @@ import { config } from '@frontend/config';
 export const initFrontendTelemetry = async (): Promise<void> => {
   const serviceName = config.otel.serviceName;
   if (!serviceName) {
+    console.log('🔭 Frontend OTel disabled');
     return;
   }
 


### PR DESCRIPTION
Log enabled/disabled state for OpenPanel analytics and frontend OTel
on startup, mirroring the backend OTel pattern.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
