### PR TITLE
✨ feat: port analytics & OTel runtime config from wise-dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,11 +32,18 @@ E2E_TEST_NAME=Playwright E2E User
 # OpenTelemetry (optional — remove comments to enable)
 # Start the local SigNoz stack first: docker compose -f docker-compose.signoz.yml up -d
 # OTEL_ENDPOINT=http://localhost:4318
-# OTEL_SERVICE_NAME=bun-boiler
+# OTEL_SERVICE_NAME=wise-geoguessr
+# ⚠️  BUN_PUBLIC_* vars are inlined by Bun's bundler at BUILD time (import.meta.env) AND injected
+#     at RUNTIME via window.__APP_CONFIG__ by the server (backend/serveProdBuild.ts). Runtime values
+#     take precedence, so you can set these on the container without rebuilding the image.
+# BUN_PUBLIC_OTEL_SERVICE_NAME=wise-geoguessr-frontend
 
-# OpenPanel Analytics (optional — remove comments to enable)
+# OpenPanel Analytics (optional — remove comments to enable, BUN_PUBLIC_ prefix required for frontend access)
 # Start the local OpenPanel stack first: docker compose -f docker-compose.openpanel.yml up -d
 # Then open http://localhost:7780, create an account, add a project, and copy its Client ID below.
+# ⚠️  BUN_PUBLIC_* vars are inlined by Bun's bundler at BUILD time (import.meta.env) AND injected
+#     at RUNTIME via window.__APP_CONFIG__ by the server (backend/serveProdBuild.ts). Runtime values
+#     take precedence, so you can set these on the container without rebuilding the image.
 # BUN_PUBLIC_OPENPANEL_CLIENT_ID=your-client-id
 # BUN_PUBLIC_OPENPANEL_API_URL=http://localhost:3001  # only needed for self-hosted
 # BUN_PUBLIC_OPENPANEL_SESSION_REPLAY=false

--- a/.github/agents/otel.agent.md
+++ b/.github/agents/otel.agent.md
@@ -13,10 +13,10 @@ Telemetry is **opt-in and zero-overhead** when disabled. The entire system activ
 
 ### Env Vars
 
-| Variable            | Example                 | Description                                                  |
-| ------------------- | ----------------------- | ------------------------------------------------------------ |
-| `OTEL_ENDPOINT`     | `http://localhost:4318` | OTLP HTTP endpoint. Unset = telemetry fully disabled.        |
-| `OTEL_SERVICE_NAME` | `bun-boiler`            | Identifies this service in SigNoz. Defaults to `bun-boiler`. |
+| Variable            | Example                 | Description                                                      |
+| ------------------- | ----------------------- | ---------------------------------------------------------------- |
+| `OTEL_ENDPOINT`     | `http://localhost:4318` | OTLP HTTP endpoint. Unset = telemetry fully disabled.            |
+| `OTEL_SERVICE_NAME` | `wise-geoguessr`        | Identifies this service in SigNoz. Defaults to `wise-geoguessr`. |
 
 ### Local Stack
 
@@ -68,24 +68,17 @@ Never use `console.log/warn/error` directly in backend code — use `logger`.
 ## ➕ Adding Traces (Spans)
 
 ```ts
-import { trace } from '@opentelemetry/api';
+import { withSpan } from '@backend/telemetry';
 
-const tracer = trace.getTracer('bun-boiler');
-
-const result = await tracer.startActiveSpan('user.create', async (span) => {
-  try {
-    span.setAttribute('user.email', email);
+const result = await withSpan(
+  'user.create',
+  { 'user.role': role },
+  async (span) => {
     const user = await repo.create(email, name);
     span.setAttribute('user.id', user.id);
     return user;
-  } catch (err) {
-    span.recordException(err as Error);
-    span.setStatus({ code: SpanStatusCode.ERROR });
-    throw err;
-  } finally {
-    span.end();
-  }
-});
+  },
+);
 ```
 
 **When to add spans:**

--- a/backend/serveProdBuild.ts
+++ b/backend/serveProdBuild.ts
@@ -1,19 +1,26 @@
 import { join } from 'path';
 
-// Collect all BUN_PUBLIC_* vars from the server's runtime environment and
-// inject them into the HTML so the browser can read them via window.__BUN_PUBLIC_ENV.
-// This allows env vars to be set on the running container rather than at
-// image build time (where they would be baked in as undefined).
-const buildPublicEnvScript = (): string => {
-  const publicEnv = Object.fromEntries(
-    Object.entries(Bun.env).filter(([key]) => key.startsWith('BUN_PUBLIC_')),
-  );
-  return `<script>window.__BUN_PUBLIC_ENV=${JSON.stringify(publicEnv)};</script>`;
-};
+// BUN_PUBLIC_* vars are inlined by Bun's bundler at build time, which means
+// they're empty when the image is built without them (e.g. Coolify supplies
+// env vars at runtime, not build time).  To fix this, we inject a small
+// <script> block into every HTML response that writes the live values from
+// Bun.env into window.__APP_CONFIG__.  frontend/config.ts prefers this object
+// over import.meta.env, so runtime values always win.
+const runtimeConfigScript = (() => {
+  const cfg = {
+    BUN_PUBLIC_OPENPANEL_CLIENT_ID:
+      Bun.env.BUN_PUBLIC_OPENPANEL_CLIENT_ID ?? '',
+    BUN_PUBLIC_OPENPANEL_API_URL: Bun.env.BUN_PUBLIC_OPENPANEL_API_URL ?? '',
+    BUN_PUBLIC_OPENPANEL_SESSION_REPLAY:
+      Bun.env.BUN_PUBLIC_OPENPANEL_SESSION_REPLAY ?? '',
+    BUN_PUBLIC_OTEL_SERVICE_NAME: Bun.env.BUN_PUBLIC_OTEL_SERVICE_NAME ?? '',
+  };
+  return `<script>window.__APP_CONFIG__=${JSON.stringify(cfg)};</script>`;
+})();
 
 const serveHtml = async (htmlPath: string): Promise<Response> => {
   const html = await Bun.file(htmlPath).text();
-  const injected = html.replace('</head>', `${buildPublicEnvScript()}</head>`);
+  const injected = html.replace('</head>', `${runtimeConfigScript}</head>`);
   return new Response(injected, { headers: { 'Content-Type': 'text/html' } });
 };
 

--- a/backend/telemetry/index.ts
+++ b/backend/telemetry/index.ts
@@ -46,7 +46,7 @@ type SpanHandle = {
 // ---------------------------------------------------------------------------
 // Internal state — set by initTelemetry()
 // ---------------------------------------------------------------------------
-const SERVICE_NAME = 'bun-boiler';
+const SERVICE_NAME = 'wise-geoguessr';
 
 /** True once initTelemetry() has registered providers. */
 let _enabled = false;

--- a/bun-env.d.ts
+++ b/bun-env.d.ts
@@ -55,7 +55,7 @@ declare module 'bun' {
 
     // OpenTelemetry — optional, only active when OTEL_ENDPOINT is set
     OTEL_ENDPOINT?: string; // e.g. http://localhost:4318
-    OTEL_SERVICE_NAME?: string; // defaults to "bun-boiler"
+    OTEL_SERVICE_NAME?: string; // defaults to "wise-geoguessr"
 
     // OpenPanel Analytics — optional, only active when BUN_PUBLIC_OPENPANEL_CLIENT_ID is set
     // BUN_PUBLIC_ prefix is required for Bun to expose these to the frontend bundle
@@ -65,7 +65,7 @@ declare module 'bun' {
 
     // Frontend OpenTelemetry — optional, only active when BUN_PUBLIC_OTEL_SERVICE_NAME is set
     // BUN_PUBLIC_ prefix exposes this to frontend code at build time
-    BUN_PUBLIC_OTEL_SERVICE_NAME?: string; // e.g. "bun-boiler-frontend"
+    BUN_PUBLIC_OTEL_SERVICE_NAME?: string; // e.g. "wise-geoguessr-frontend"
 
     // SMTP Mail — optional, only active when SMTP_HOST is set
     SMTP_HOST?: string; // e.g. smtp.example.com
@@ -96,6 +96,15 @@ interface ImportMetaEnv {
 }
 
 interface Window {
-  /** Runtime-injected public env vars (see backend/serveProdBuild.ts). */
-  __BUN_PUBLIC_ENV?: ImportMetaEnv;
+  /**
+   * Runtime config injected into HTML by the server (backend/serveProdBuild.ts).
+   * Allows deployments that supply env vars at runtime (e.g. Coolify) to work
+   * correctly even when the Docker image was built without those vars.
+   */
+  __APP_CONFIG__?: {
+    BUN_PUBLIC_OPENPANEL_CLIENT_ID?: string;
+    BUN_PUBLIC_OPENPANEL_API_URL?: string;
+    BUN_PUBLIC_OPENPANEL_SESSION_REPLAY?: string;
+    BUN_PUBLIC_OTEL_SERVICE_NAME?: string;
+  };
 }

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -77,27 +77,40 @@ Client-side env vars must be prefixed `BUN_PUBLIC_`.
   env = "BUN_PUBLIC_*"
   ```
 
-- **Production** — they are **not baked in at build time**. `backend/serveProdBuild.ts` reads `Bun.env` at request time and injects `<script>window.__BUN_PUBLIC_ENV={...}</script>` into `index.html` before serving it. Set `BUN_PUBLIC_*` vars on the running container and they are picked up without rebuilding the image.
+- **Production** — they are **not baked in at build time**. `backend/serveProdBuild.ts` reads `Bun.env` at request time and injects `<script>window.__APP_CONFIG__={...}</script>` into `index.html` before serving it. Set `BUN_PUBLIC_*` vars on the running container and they are picked up without rebuilding the image.
 
 ### Config pattern
 
-`frontend/config.ts` is the **single source of truth** for all `BUN_PUBLIC_*` vars. In production it reads from `window.__BUN_PUBLIC_ENV` (runtime injection); in development it falls back to `import.meta.env`:
+`frontend/config.ts` is the **single source of truth** for all `BUN_PUBLIC_*` vars. It uses a per-property priority pattern: `window.__APP_CONFIG__` (runtime injection) takes precedence over `import.meta.env` (build-time), so deployments that supply env vars at runtime (e.g. Coolify) work without rebuilding the image:
 
 ```ts
-const env: ImportMetaEnv | undefined =
-  typeof window !== 'undefined' && window.__BUN_PUBLIC_ENV
-    ? window.__BUN_PUBLIC_ENV
-    : (import.meta.env as ImportMetaEnv | undefined);
+const runtimeConfig =
+  typeof window !== 'undefined' ? window.__APP_CONFIG__ : undefined;
+const env = import.meta.env as ImportMetaEnv | undefined;
 
 export const config = {
   openpanel: {
-    clientId: env?.BUN_PUBLIC_OPENPANEL_CLIENT_ID ?? null,
-    apiUrl: env?.BUN_PUBLIC_OPENPANEL_API_URL ?? null,
-    sessionReplay: env?.BUN_PUBLIC_OPENPANEL_SESSION_REPLAY === 'true',
+    clientId:
+      runtimeConfig?.BUN_PUBLIC_OPENPANEL_CLIENT_ID ||
+      env?.BUN_PUBLIC_OPENPANEL_CLIENT_ID ||
+      null,
+    apiUrl:
+      runtimeConfig?.BUN_PUBLIC_OPENPANEL_API_URL ||
+      env?.BUN_PUBLIC_OPENPANEL_API_URL ||
+      null,
+    sessionReplay:
+      (runtimeConfig?.BUN_PUBLIC_OPENPANEL_SESSION_REPLAY ??
+        env?.BUN_PUBLIC_OPENPANEL_SESSION_REPLAY) === 'true',
+  },
+  otel: {
+    serviceName:
+      runtimeConfig?.BUN_PUBLIC_OTEL_SERVICE_NAME ||
+      env?.BUN_PUBLIC_OTEL_SERVICE_NAME ||
+      null,
   },
 } as const;
 ```
 
-- **Must** add new `BUN_PUBLIC_*` vars to `config.ts` — never read them elsewhere
-- **Must not** access `import.meta.env` or `window.__BUN_PUBLIC_ENV` directly outside `config.ts`
+- **Must** add new `BUN_PUBLIC_*` vars to `config.ts` **and** `backend/serveProdBuild.ts` — never read them elsewhere
+- **Must not** access `import.meta.env` or `window.__APP_CONFIG__` directly outside `config.ts`
 - Import via `@frontend/config`: `import { config } from '@frontend/config'`

--- a/frontend/config.ts
+++ b/frontend/config.ts
@@ -1,31 +1,41 @@
 /**
  * Safe access to BUN_PUBLIC_* env vars for frontend (browser) code.
  *
- * import.meta.env is always an object, but individual properties are
- * undefined when the corresponding BUN_PUBLIC_* var is not set. All reads
- * go through optional chaining with null fallbacks so callers always get a
- * typed string | null rather than string | undefined.
+ * Priority: window.__APP_CONFIG__ (runtime, injected by the server) takes
+ * precedence over import.meta.env (build-time, inlined by the bundler).
+ * This ensures deployments that supply env vars at runtime (e.g. Coolify)
+ * work correctly even when the Docker image was built without those vars.
  *
- * Never access import.meta.env directly outside this file.
+ * Never access import.meta.env or window.__APP_CONFIG__ directly outside this file.
  */
-const env: ImportMetaEnv | undefined =
-  typeof window !== 'undefined' && window.__BUN_PUBLIC_ENV
-    ? window.__BUN_PUBLIC_ENV
-    : (import.meta.env as ImportMetaEnv | undefined);
+const runtimeConfig =
+  typeof window !== 'undefined' ? window.__APP_CONFIG__ : undefined;
+const env = import.meta.env as ImportMetaEnv | undefined;
 
 export const config = {
   openpanel: {
-    clientId: env?.BUN_PUBLIC_OPENPANEL_CLIENT_ID ?? null,
-    apiUrl: env?.BUN_PUBLIC_OPENPANEL_API_URL ?? null,
-    sessionReplay: env?.BUN_PUBLIC_OPENPANEL_SESSION_REPLAY === 'true',
+    clientId:
+      runtimeConfig?.BUN_PUBLIC_OPENPANEL_CLIENT_ID ||
+      env?.BUN_PUBLIC_OPENPANEL_CLIENT_ID ||
+      null,
+    apiUrl:
+      runtimeConfig?.BUN_PUBLIC_OPENPANEL_API_URL ||
+      env?.BUN_PUBLIC_OPENPANEL_API_URL ||
+      null,
+    sessionReplay:
+      (runtimeConfig?.BUN_PUBLIC_OPENPANEL_SESSION_REPLAY ??
+        env?.BUN_PUBLIC_OPENPANEL_SESSION_REPLAY) === 'true',
   },
   otel: {
     /**
      * Service name reported in browser traces.
      * Set BUN_PUBLIC_OTEL_SERVICE_NAME to enable frontend tracing
-     * (e.g. "bun-boiler-frontend"). When null, the frontend OTel SDK is
+     * (e.g. "wise-geoguessr-frontend"). When null, the frontend OTel SDK is
      * never loaded. Spans are proxied via /api/telemetry/traces.
      */
-    serviceName: env?.BUN_PUBLIC_OTEL_SERVICE_NAME ?? null,
+    serviceName:
+      runtimeConfig?.BUN_PUBLIC_OTEL_SERVICE_NAME ||
+      env?.BUN_PUBLIC_OTEL_SERVICE_NAME ||
+      null,
   },
 } as const;

--- a/frontend/features/analytics/README.md
+++ b/frontend/features/analytics/README.md
@@ -74,10 +74,25 @@ identify(user.id, { name: user.name });
 clearIdentity();
 ```
 
+## How Env Vars Are Read (Runtime vs Build Time)
+
+Analytics env vars are picked up from **two sources**, with runtime winning:
+
+| Source                  | When                                         | Priority   |
+| ----------------------- | -------------------------------------------- | ---------- |
+| `window.__APP_CONFIG__` | Page load — injected into HTML by the server | **Higher** |
+| `import.meta.env`       | Bundle build — inlined by Bun's bundler      | Lower      |
+
+`backend/serveProdBuild.ts` writes a `<script>window.__APP_CONFIG__={…}</script>` block into every HTML response before `</head>`, reading live values from `Bun.env` at server startup. `frontend/config.ts` prefers this object over `import.meta.env`, so runtime values always win.
+
+**Practical effect:** you can deploy a Docker image that was built without analytics configured and enable it later by setting the env vars on the running container — no image rebuild required. This is important for platforms like Coolify or Fly.io that supply secrets at deploy time rather than build time.
+
+> Never access `window.__APP_CONFIG__` or `import.meta.env` directly. Always go through `config.openpanel.*` from `frontend/config.ts`.
+
 ## Files
 
-| File                    | Purpose                                                          |
-| ----------------------- | ---------------------------------------------------------------- |
-| `analyticsProvider.tsx` | Initialises OpenPanel; tracks SPA route changes as `screen_view` |
-| `useAnalytics.ts`       | Hook exposing `trackEvent`, `identify`, and `clearIdentity`      |
-| `../../config.ts`       | Shared env-var wrapper — `config.openpanel.*` read from here     |
+| File                    | Purpose                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------ |
+| `analyticsProvider.tsx` | Initialises OpenPanel; tracks SPA route changes as `screen_view`                           |
+| `useAnalytics.ts`       | Hook exposing `trackEvent`, `identify`, and `clearIdentity`                                |
+| `../../config.ts`       | Single source of truth for env vars — reads `window.__APP_CONFIG__` then `import.meta.env` |


### PR DESCRIPTION
- Fix SERVICE_NAME 'bun-boiler' → 'wise-geoguessr' in backend telemetry
- Adopt window.__APP_CONFIG__ per-property pattern in frontend/config.ts
  (replaces all-or-nothing __BUN_PUBLIC_ENV; each var now falls back
  individually to import.meta.env so runtime always wins over build-time)
- Update backend/serveProdBuild.ts to inject explicit __APP_CONFIG__ shape
- Update bun-env.d.ts Window interface: __BUN_PUBLIC_ENV → __APP_CONFIG__
- Fix .env.example service names and add BUN_PUBLIC_OTEL_SERVICE_NAME example
- Update frontend/README.md, frontend/features/analytics/README.md,
  and .github/agents/otel.agent.md to reflect new runtime config pattern

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
