### PR TITLE
🐛 fix: make Sigurd and Malin chart colors clearly distinguishable

### DIFF
--- a/frontend/features/geoguessr/constants.ts
+++ b/frontend/features/geoguessr/constants.ts
@@ -4,7 +4,7 @@ const PLAYER_COLORS: Record<string, string> = {
   Thomas: '#65a30d',
   'Tor Arve': '#f97316',
   Sigurd: '#7c3aed',
-  Malin: '#9333ea',
+  Malin: '#d97706',
   Lotte: '#0891b2',
   Margaux: '#2563eb',
   Eirik: '#0f766e',


### PR DESCRIPTION
Sigurd (`#7c3aed`, violet) and Malin (`#9333ea`, purple) were nearly identical in charts.

Changed Malin to `#d97706` (amber) — now on the opposite end of the warm/cool spectrum from Sigurd's violet, making them easy to tell apart at a glance.